### PR TITLE
Add video embed handlers to support cookieinformation.com

### DIFF
--- a/ulf_aarhus_settings.module
+++ b/ulf_aarhus_settings.module
@@ -29,6 +29,7 @@ function ulf_aarhus_settings_mail_alter(&$message) {
  */
 function ulf_aarhus_settings_video_embed_handler_info_alter(&$info) {
   $info['youtube']['function'] = '_ulf_aarhus_settings_youtube_embed';
+  $info['vimeo']['function'] = '_ulf_aarhus_settings_vimeo_embed';
 }
 
 /**
@@ -78,4 +79,45 @@ function _ulf_aarhus_settings_youtube_embed($url, $settings) {
   $output['#markup'] = '<iframe src="" data-category-consent="cookie_cat_statistic" class="' . check_plain($class) . '" width="' . check_plain($settings['width']) . '" height="' . check_plain($settings['height']) . '" data-consent-src="//www.youtube.com/embed/' . $id . '?' . $settings_str . '" frameborder="0" allowfullscreen></iframe>';
 
   return $output;
+}
+
+/**
+ * Custom vimeo embed handler.
+ * Grabbed from video_embed_field/video_embed_field.handlers.inc and added
+ * consent attributes.
+ *
+ * @param $url
+ * @param $settings
+ *
+ * @return array
+ */
+function _ulf_aarhus_settings_vimeo_embed($url, $settings) {
+  $vimeo_data = _video_embed_field_get_vimeo_data($url);
+
+  // Get ID of video from URL.
+  $id = _video_embed_field_get_vimeo_id($vimeo_data);
+
+  if (empty($id)) {
+    return array(
+      '#markup' => l($url, $url),
+    );
+  }
+
+  // Construct the embed code.
+  $settings['player_id'] = drupal_html_id('vimeo-' . $id);
+  if (!empty($settings['froogaloop'])) {
+    $settings['api'] = 1;
+  }
+  unset($settings['froogaloop']);
+
+  // Add class to variable to avoid adding it to URL param string.
+  $class = $settings['class'];
+  unset($settings['class']);
+
+  $settings_str = _video_embed_code_get_settings_str($settings);
+
+  return array(
+    '#markup' => '<iframe src="" data-category-consent="cookie_cat_statistic" class="' . check_plain($class) . '" id="' . $settings['player_id'] . '" width="' . check_plain($settings['width']) . '" height="' . check_plain($settings['height']) . '" data-consent-src="//player.vimeo.com/video/' . $id .
+      '?' . $settings_str . '" frameborder="0" webkitAllowFullScreen mozallowfullscreen allowfullscreen></iframe>',
+  );
 }

--- a/ulf_aarhus_settings.module
+++ b/ulf_aarhus_settings.module
@@ -16,10 +16,66 @@ function ulf_aarhus_settings_default_search_api_index_alter(&$defaults) {
  */
 function ulf_aarhus_settings_mail_alter(&$message) {
   $default_from = variable_get('site_mail', ini_get('sendmail_from'));
-  $message['from'] = 'ULF i Aarhus <'. $default_from .'>';
+  $message['from'] = 'ULF i Aarhus <' . $default_from . '>';
   $message['headers']['From'] = $message['headers']['Sender'] = $message['headers']['Return-Path'] = $message['headers']['Errors-To'] = $message['from'];
 
-  if(empty($message['headers']['Reply-to'])) {
+  if (empty($message['headers']['Reply-to'])) {
     $message['headers']['Reply-To'] = $message['from'];
   }
+}
+
+/**
+ * Implements hook_video_embed_handler_info_alter().
+ */
+function ulf_aarhus_settings_video_embed_handler_info_alter(&$info) {
+  $info['youtube']['function'] = '_ulf_aarhus_settings_youtube_embed';
+}
+
+/**
+ * Custom youtube embed handler.
+ * Grabbed from video_embed_field/video_embed_field.handlers.inc and added
+ * consent attributes.
+ *
+ * @param $url
+ * @param $settings
+ *
+ * @return array
+ */
+function _ulf_aarhus_settings_youtube_embed($url, $settings) {
+  $output = array();
+
+  if(preg_match('/#t=((?P<min>\d+)m)?((?P<sec>\d+)s)?((?P<tinsec>\d+))?/', $url, $matches)){
+    if(isset($matches['tinsec'])){
+      $settings['start'] = $matches['tinsec']; // url already in form #t=125 for 2 minutes and 5 seconds
+    } else {
+      // url in form #t=2m5s or with other useless data, this is why we still keep adding the default data..
+      // give it some default data in case there is no #t=...
+      $matches += array(
+        "min" => 0,
+        "sec" => 0,
+      );
+      if ($time = ($matches["min"] * 60) + $matches["sec"]) {
+        $settings['start'] = $time;
+      }
+    }
+  }
+
+  $id = _video_embed_field_get_youtube_id($url);
+  if (!$id) {
+    // We can't decode the URL - just return the URL as a link.
+    $output['#markup'] = l($url, $url);
+    return $output;
+  }
+
+  // Add class to variable to avoid adding it to URL param string.
+  $class = $settings['class'];
+  unset($settings['class']);
+
+  // Construct the embed code.
+  $settings['wmode'] = 'opaque';
+  $settings_str = urlencode(_video_embed_code_get_settings_str($settings));
+
+  $output['#markup'] = '<iframe src="" data-category-consent="cookie_cat_statistic" class="' . check_plain($class) . '" width="' . check_plain($settings['width']) . '" height="' . check_plain($settings['height']) . '" data-consent-src="//www.youtube.com/embed/' . $id . '?' . $settings_str . '" frameborder="0" allowfullscreen></iframe>';
+
+  return $output;
 }


### PR DESCRIPTION
We change the handlers used to add Vimeo and Youtube iframes and modify the iframe html.